### PR TITLE
lazily load default logger if no logger provided

### DIFF
--- a/slogtripper.go
+++ b/slogtripper.go
@@ -89,7 +89,7 @@ type SlogTripper struct {
 
 func NewSlogTripper(opts ...Option) *SlogTripper {
 	st := &SlogTripper{
-		logger:         slog.Default(),
+		logger:         nil,
 		logAtLevel:     slog.LevelInfo,
 		proxyTransport: http.DefaultTransport,
 	}
@@ -198,10 +198,15 @@ func (st *SlogTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (st *SlogTripper) log(ctx context.Context, msg string, args ...any) {
+	logger := st.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	switch st.logAtLevel {
 	case slog.LevelDebug:
-		st.logger.DebugContext(ctx, msg, args...)
+		logger.DebugContext(ctx, msg, args...)
 	case slog.LevelInfo:
-		st.logger.InfoContext(ctx, msg, args...)
+		logger.InfoContext(ctx, msg, args...)
 	}
 }


### PR DESCRIPTION
 slogtripper was capturing the `slog.Default` logger on creation so if the default logger changed between creation of slogtripper and the actual log being written, slogtripper would use the original default not the new default logger. This made it impossible to dynamically adjust log levels at runtime without recreating the slogtripper instance (and potentially the whole http client/transport stack).

The change here is to still allow a user to pass in a logger if they choose with `WithLogger`, but instead of initialising to `slog.Default()` on creation the actual log function will check if there's an explicit logger or fallback on `slog.Default()` if unset; this way if you leave the logger as `nil` then `slog.Default()` will still be used, but if the default changes between creation and logging the latest default will always be used.